### PR TITLE
Fixed default argument value on edit_videos

### DIFF
--- a/bilibiliuploader/core.py
+++ b/bilibiliuploader/core.py
@@ -628,7 +628,7 @@ def edit_videos(
         tag=None,
         desc=None,
         source=None,
-        cover=None,
+        cover='',
         no_reprint=None,
         open_elec=None,
         max_retry: int = 5,


### PR DESCRIPTION
The default None type in Line 631 leads to Error in Line 713. 